### PR TITLE
[#19] userId로 delete 처리 (멱등성 유지) 

### DIFF
--- a/src/main/java/com/dsg/wardstudy/controller/reservation/ReservationController.java
+++ b/src/main/java/com/dsg/wardstudy/controller/reservation/ReservationController.java
@@ -87,7 +87,7 @@ public class ReservationController {
     public ResponseEntity<String> deleteById(
             @PathVariable("userId") Long userId,
             @PathVariable("reservationId") String reservationId) {
-        log.info("reservation deleteById, reservationId: {}", reservationId);
+        log.info("reservation deleteById, userId: {}, reservationId: {}" ,userId, reservationId);
         reservationService.deleteById(userId, reservationId);
         return new ResponseEntity<>("a reservation successfully deleted!", HttpStatus.OK);
     }

--- a/src/main/java/com/dsg/wardstudy/controller/reservation/ReservationController.java
+++ b/src/main/java/com/dsg/wardstudy/controller/reservation/ReservationController.java
@@ -83,10 +83,12 @@ public class ReservationController {
     }
 
     // 예약 삭제
-    @DeleteMapping("/reservation/{reservationId}")
-    public ResponseEntity<String> deleteById(@PathVariable("reservationId") String reservationId) {
+    @DeleteMapping("/users/{userId}/reservation/{reservationId}")
+    public ResponseEntity<String> deleteById(
+            @PathVariable("userId") Long userId,
+            @PathVariable("reservationId") String reservationId) {
         log.info("reservation deleteById, reservationId: {}", reservationId);
-        reservationService.deleteById(reservationId);
+        reservationService.deleteById(userId, reservationId);
         return new ResponseEntity<>("a reservation successfully deleted!", HttpStatus.OK);
     }
 

--- a/src/main/java/com/dsg/wardstudy/controller/studyGroup/StudyGroupController.java
+++ b/src/main/java/com/dsg/wardstudy/controller/studyGroup/StudyGroupController.java
@@ -41,10 +41,12 @@ public class StudyGroupController {
     // 스터디그룹 전체조회
     @GetMapping("/study-group")
     public ResponseEntity<PageResponse.StudyGroup> getAllPage(
-            @PageableDefault(page = 0, size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
+            @PageableDefault(page = 0, size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
+            @RequestParam(value = "type", required = false) String type,
+            @RequestParam(value = "keyword", required = false) String keyword
             ) {
-        log.info("studyGroup getAll");
-        return ResponseEntity.ok(studyGroupService.getAll(pageable));
+        log.info("studyGroup getAll type: {}, keyword: {}", type, keyword);
+        return ResponseEntity.ok(studyGroupService.getAll(pageable, type, keyword));
     }
 
     // 사용자가 참여한 스터디그룹 조회

--- a/src/main/java/com/dsg/wardstudy/exception/WSExceptionHandler.java
+++ b/src/main/java/com/dsg/wardstudy/exception/WSExceptionHandler.java
@@ -1,8 +1,5 @@
 package com.dsg.wardstudy.exception;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpHeaders;
@@ -28,7 +25,7 @@ public class WSExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler(WSApiException.class)
     public ResponseEntity<Object> handleWSApiException(
             WSApiException exception,
-            WebRequest request) throws JsonProcessingException {
+            WebRequest request) {
 
 
         log.error("WSApiException: ", exception);

--- a/src/main/java/com/dsg/wardstudy/exception/WSExceptionHandler.java
+++ b/src/main/java/com/dsg/wardstudy/exception/WSExceptionHandler.java
@@ -24,12 +24,6 @@ import static com.dsg.wardstudy.exception.ErrorHttpStatusMapper.mapToStatus;
 @ControllerAdvice
 public class WSExceptionHandler extends ResponseEntityExceptionHandler {
 
-    private final ObjectMapper objectMapper;
-
-    public WSExceptionHandler() {
-        this.objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
-    }
-
     // handle specific exceptions
     @ExceptionHandler(WSApiException.class)
     public ResponseEntity<Object> handleWSApiException(
@@ -47,7 +41,7 @@ public class WSExceptionHandler extends ResponseEntityExceptionHandler {
                 .build();
 
         log.info("errorDetails: {}", errorDetails);
-        return new ResponseEntity<>(objectMapper.writeValueAsString(errorDetails), mapToStatus(errorDetails.getErrorCode()));
+        return new ResponseEntity<>(errorDetails, mapToStatus(errorDetails.getErrorCode()));
     }
 
     //BindingResult Validation 처리
@@ -69,13 +63,8 @@ public class WSExceptionHandler extends ResponseEntityExceptionHandler {
                 .build();
 
         log.info("errorDetails: {}", errorDetails);
+        return new ResponseEntity<>(errorDetails, mapToStatus(errorDetails.getErrorCode()));
 
-        try {
-            return new ResponseEntity<>(objectMapper.writeValueAsString(errorDetails), mapToStatus(errorDetails.getErrorCode()));
-        } catch (JsonProcessingException e) {
-            e.printStackTrace();
-        }
-        return null;
     }
 
 }

--- a/src/main/java/com/dsg/wardstudy/repository/reservation/ReservationQueryRepository.java
+++ b/src/main/java/com/dsg/wardstudy/repository/reservation/ReservationQueryRepository.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Repository;
 import javax.persistence.EntityManager;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static com.dsg.wardstudy.domain.reservation.QReservation.reservation;
 
@@ -29,13 +30,12 @@ public class ReservationQueryRepository {
                 .fetch();
     }
 
-    public Reservation findByUserIdAndStudyGroupId(Long userId, Long studyGroupId) {
+    public Optional<Reservation> findByUserIdAndStudyGroupId(Long userId, Long studyGroupId) {
         return queryFactory
                 .selectFrom(reservation)
                 .where(reservation.user.id.eq(userId)
                         .and(reservation.studyGroup.id.eq(studyGroupId))
-                )
-                .fetchOne();
+                ).stream().findFirst();
 
     }
 }

--- a/src/main/java/com/dsg/wardstudy/repository/studyGroup/StudyGroupRepository.java
+++ b/src/main/java/com/dsg/wardstudy/repository/studyGroup/StudyGroupRepository.java
@@ -2,10 +2,11 @@ package com.dsg.wardstudy.repository.studyGroup;
 
 import com.dsg.wardstudy.domain.studyGroup.StudyGroup;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 
 import java.util.List;
 
-public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long> {
+public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long>, QuerydslPredicateExecutor<StudyGroup> {
 
     // in 절안에 컬렉션 findByIdIn
     List<StudyGroup> findByIdIn(List<Long> ids);

--- a/src/main/java/com/dsg/wardstudy/service/reservation/ReservationService.java
+++ b/src/main/java/com/dsg/wardstudy/service/reservation/ReservationService.java
@@ -21,7 +21,7 @@ public interface ReservationService {
 
     String updateById(Long roomId, String reservationId, ReservationUpdateRequest reservationRequest);
 
-    void deleteById(String reservationId);
+    void deleteById(Long userId, String reservationId);
 
     void changeIsEmailSent(Reservation reservation);
 

--- a/src/main/java/com/dsg/wardstudy/service/studyGroup/StudyGroupService.java
+++ b/src/main/java/com/dsg/wardstudy/service/studyGroup/StudyGroupService.java
@@ -13,7 +13,7 @@ public interface StudyGroupService {
 
     StudyGroupResponse getById(Long studyGroupId);
 
-    PageResponse.StudyGroup getAll(Pageable pageable);
+    PageResponse.StudyGroup getAll(Pageable pageable, String type, String keyword);
 
     Long updateById(Long userId, Long studyGroupId, StudyGroupRequest studyGroupRequest);
 

--- a/src/main/java/com/dsg/wardstudy/service/studyGroup/StudyGroupServiceImpl.java
+++ b/src/main/java/com/dsg/wardstudy/service/studyGroup/StudyGroupServiceImpl.java
@@ -25,6 +25,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 import java.util.Optional;
@@ -136,7 +137,7 @@ public class StudyGroupServiceImpl implements StudyGroupService {
         booleanBuilder.and(booleanExpression);
 
         // 검색 조건이 없는 경우
-        if (type == null || type.trim().length() == 0) {
+        if (!StringUtils.hasText(type)) {
             return booleanBuilder;
         }
 

--- a/src/test/java/com/dsg/wardstudy/controller/reservation/ReservationControllerTest.java
+++ b/src/test/java/com/dsg/wardstudy/controller/reservation/ReservationControllerTest.java
@@ -320,11 +320,11 @@ class ReservationControllerTest {
     @DisplayName("예약 삭제")
     void givenReservationId_whenDelete_thenReturn200() throws Exception {
         // given - precondition or setup
-        willDoNothing().given(reservationService).deleteById(reservation.getId());
+        willDoNothing().given(reservationService).deleteById(user.getId(), reservation.getId());
 
         // when - action or the behaviour that we are going test
         // then - verify the output
-        mockMvc.perform(delete("/reservation/{reservationId}", reservation.getId()))
+        mockMvc.perform(delete("/users/{userId}/reservation/{reservationId}",user.getId(), reservation.getId()))
                 .andDo(print())
                 .andExpect(status().isOk());
     }

--- a/src/test/java/com/dsg/wardstudy/controller/reservation/ReservationControllerTest.java
+++ b/src/test/java/com/dsg/wardstudy/controller/reservation/ReservationControllerTest.java
@@ -13,7 +13,6 @@ import com.dsg.wardstudy.exception.WSApiException;
 import com.dsg.wardstudy.service.reservation.ReservationService;
 import com.dsg.wardstudy.type.UserType;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/dsg/wardstudy/controller/reservation/ReservationControllerTest.java
+++ b/src/test/java/com/dsg/wardstudy/controller/reservation/ReservationControllerTest.java
@@ -61,8 +61,6 @@ class ReservationControllerTest {
 
     @BeforeEach
     void setUp() {
-        objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
-
         user = User.builder()
                 .id(1L)
                 .build();

--- a/src/test/java/com/dsg/wardstudy/controller/studyGroup/StudyGroupControllerTest.java
+++ b/src/test/java/com/dsg/wardstudy/controller/studyGroup/StudyGroupControllerTest.java
@@ -11,7 +11,6 @@ import com.dsg.wardstudy.exception.WSApiException;
 import com.dsg.wardstudy.service.studyGroup.StudyGroupService;
 import com.dsg.wardstudy.type.UserType;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/com/dsg/wardstudy/controller/studyGroup/StudyGroupControllerTest.java
+++ b/src/test/java/com/dsg/wardstudy/controller/studyGroup/StudyGroupControllerTest.java
@@ -56,9 +56,6 @@ class StudyGroupControllerTest {
 
     @BeforeEach
     void setup() {
-
-        objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
-
         studyGroup = StudyGroup.builder()
                 .title("testSG")
                 .content("인원 4명의 스터디그룹을 모집합니다.")

--- a/src/test/java/com/dsg/wardstudy/controller/studyGroup/StudyGroupControllerTest.java
+++ b/src/test/java/com/dsg/wardstudy/controller/studyGroup/StudyGroupControllerTest.java
@@ -1,5 +1,6 @@
 package com.dsg.wardstudy.controller.studyGroup;
 
+import com.dsg.wardstudy.domain.studyGroup.QStudyGroup;
 import com.dsg.wardstudy.domain.studyGroup.StudyGroup;
 import com.dsg.wardstudy.domain.user.User;
 import com.dsg.wardstudy.domain.user.UserGroup;
@@ -11,6 +12,7 @@ import com.dsg.wardstudy.exception.WSApiException;
 import com.dsg.wardstudy.service.studyGroup.StudyGroupService;
 import com.dsg.wardstudy.type.UserType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.querydsl.core.BooleanBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -119,7 +121,22 @@ class StudyGroupControllerTest {
         }
         Pageable pageable = PageRequest.of(0, 10, Sort.by("id").descending());
 
-        given(studyGroupService.getAll(pageable))
+        QStudyGroup qStudyGroup = QStudyGroup.studyGroup;
+
+        String type = "t";
+        String keyword = "test";
+
+        // 검색조건 추가
+        BooleanBuilder conditionBuilder = new BooleanBuilder();
+
+        if(type.contains("t")) {
+            conditionBuilder.or(qStudyGroup.title.contains(keyword));
+        }
+        if(type.contains("c")) {
+            conditionBuilder.or(qStudyGroup.content.contains(keyword));
+        }
+
+        given(studyGroupService.getAll(pageable, type, keyword))
                 .willReturn(PageResponse.StudyGroup.builder()
                         .content(studyGroupResponses)
                         .pageNo(pageable.getPageNumber())
@@ -133,11 +150,13 @@ class StudyGroupControllerTest {
                         .param("page", "0")
                         .param("size", "10")
                         .param("sort", "id,desc")
+                        .param("type", "t")
+                        .param("keyword", "test")
                 )
                 .andDo(print())
                 .andExpect(status().isOk());
 
-        verify(studyGroupService).getAll(pageable);
+        verify(studyGroupService).getAll(pageable, type, keyword);
     }
 
     @Test

--- a/src/test/java/com/dsg/wardstudy/service/reservation/ReservationServiceTest.java
+++ b/src/test/java/com/dsg/wardstudy/service/reservation/ReservationServiceTest.java
@@ -313,11 +313,13 @@ class ReservationServiceTest {
     @Test
     void givenReservationId_whenDelete_thenNothing() {
         // given - precondition or setup
+        given(userRepository.findById(user.getId()))
+                .willReturn(Optional.of(user));
         given(reservationRepository.findById(reservation.getId()))
                 .willReturn(Optional.of(reservation));
 
         // when - action or the behaviour that we are going test
-        reservationService.deleteById(reservation.getId());
+        reservationService.deleteById(user.getId(), reservation.getId());
 
         // then - verify the output
         verify(reservationRepository).delete(reservation);

--- a/src/test/java/com/dsg/wardstudy/service/studyGroup/StudyGroupServiceTest.java
+++ b/src/test/java/com/dsg/wardstudy/service/studyGroup/StudyGroupServiceTest.java
@@ -228,17 +228,17 @@ class StudyGroupServiceTest {
         Long userId = 1L;
         Long studyGroupId = 1L;
 
+        given(reservationQueryRepository.findByUserIdAndStudyGroupId(anyLong(), anyLong()))
+                .willReturn(Optional.ofNullable(reservation));
+
         given(userRepository.findById(anyLong()))
                 .willReturn(Optional.of(user));
-
-        given(studyGroupRepository.findById(anyLong()))
-                .willReturn(Optional.of(studyGroup));
 
         given(userGroupRepository.findUserTypeByUserIdAndSGId(anyLong(), anyLong()))
                 .willReturn(Optional.of(UserType.L));
 
-        given(reservationQueryRepository.findByUserIdAndStudyGroupId(anyLong(), anyLong()))
-                .willReturn(reservation);
+        given(studyGroupRepository.findById(anyLong()))
+                .willReturn(Optional.of(studyGroup));
 
         willDoNothing().given(reservationRepository).delete(reservation);
         willDoNothing().given(studyGroupRepository).delete(studyGroup);

--- a/src/test/java/com/dsg/wardstudy/service/studyGroup/StudyGroupServiceTest.java
+++ b/src/test/java/com/dsg/wardstudy/service/studyGroup/StudyGroupServiceTest.java
@@ -1,6 +1,7 @@
 package com.dsg.wardstudy.service.studyGroup;
 
 import com.dsg.wardstudy.domain.reservation.Reservation;
+import com.dsg.wardstudy.domain.studyGroup.QStudyGroup;
 import com.dsg.wardstudy.domain.studyGroup.StudyGroup;
 import com.dsg.wardstudy.domain.user.User;
 import com.dsg.wardstudy.domain.user.UserGroup;
@@ -14,6 +15,7 @@ import com.dsg.wardstudy.repository.studyGroup.StudyGroupRepository;
 import com.dsg.wardstudy.repository.user.UserGroupRepository;
 import com.dsg.wardstudy.repository.user.UserRepository;
 import com.dsg.wardstudy.type.UserType;
+import com.querydsl.core.BooleanBuilder;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -148,7 +150,7 @@ class StudyGroupServiceTest {
 
     @Test
     public void givenStudyGroupList_whenGetAll_thenReturnStudyGroupResponseList() {
-        // TODO : paging NPE 발생 issue#23
+        // TODO : paging NPE 발생 issue#23 findAll(pageable)부터 안됐음.
         // given - precondition or setup
         StudyGroup studyGroup1 = StudyGroup.builder()
                 .id(100L)
@@ -156,14 +158,29 @@ class StudyGroupServiceTest {
                 .content("인원 6명의 스터디그룹을 모집합니다.")
                 .build();
 
-        Pageable pageable = PageRequest.of(0, 2, Sort.by("id").descending());
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("id").descending());
 
-        given(studyGroupRepository.findAll(pageable).getContent())
+        QStudyGroup qStudyGroup = QStudyGroup.studyGroup;
+
+        String type = "t";
+        String keyword = "test";
+
+        // 검색조건 추가
+        BooleanBuilder conditionBuilder = new BooleanBuilder();
+
+        if(type.contains("t")) {
+            conditionBuilder.or(qStudyGroup.title.contains(keyword));
+        }
+        if(type.contains("c")) {
+            conditionBuilder.or(qStudyGroup.content.contains(keyword));
+        }
+
+        given(studyGroupRepository.findAll(conditionBuilder, pageable).getContent())
                 .willReturn(List.of(studyGroup, studyGroup1));
         // when - action or the behaviour that we are going test
 
 
-        PageResponse.StudyGroup studyGroupPageResponses = studyGroupService.getAll(pageable);
+        PageResponse.StudyGroup studyGroupPageResponses = studyGroupService.getAll(pageable, type, keyword);
         log.info("studyGroupPageResponses: {}", studyGroupPageResponses);
         // then - verify the output
         assertThat(studyGroupPageResponses).isNotNull();
@@ -173,6 +190,7 @@ class StudyGroupServiceTest {
 
     @Test
     public void givenStudyGroupList_whenGetAll_Negative_thenReturnStudyGroupResponseList() {
+        // TODO : paging NPE 발생 issue#23
         // given - precondition or setup
         StudyGroup studyGroup1 = StudyGroup.builder()
                 .id(2L)
@@ -182,10 +200,25 @@ class StudyGroupServiceTest {
 
         Pageable pageable = PageRequest.of(0, 10, Sort.by("id").descending());
 
-        given(studyGroupRepository.findAll(pageable).getContent())
+        QStudyGroup qStudyGroup = QStudyGroup.studyGroup;
+
+        String type = "t";
+        String keyword = "test";
+
+        // 검색조건 추가
+        BooleanBuilder conditionBuilder = new BooleanBuilder();
+
+        if(type.contains("t")) {
+            conditionBuilder.or(qStudyGroup.title.contains(keyword));
+        }
+        if(type.contains("c")) {
+            conditionBuilder.or(qStudyGroup.content.contains(keyword));
+        }
+
+        given(studyGroupRepository.findAll(conditionBuilder, pageable).getContent())
                 .willReturn(Collections.emptyList());
         // when - action or the behaviour that we are going test
-        PageResponse.StudyGroup studyGroupPageResponses = studyGroupService.getAll(pageable);
+        PageResponse.StudyGroup studyGroupPageResponses = studyGroupService.getAll(pageable, type, keyword);
         log.info("studyGroupPageResponses: {}", studyGroupPageResponses);
         // then - verify the output
         assertThat(studyGroupPageResponses).isNull();


### PR DESCRIPTION
### Description
* validate 처리에서 해당 userId에 따라 delete 할 수 있게 처리
* 멱등성 유지
* test 구현
* ErrorDetails LocalDateTime 직렬화 문제 해결 - cache 제거후 정상동작됨. JavaTimeModule 제거

### 중요 Commit 정리
* [delete 멱등성 유지한 채 userId로 delete 할 수 있게 구현](https://github.com/f-lab-edu/ward-study-reservation/commit/bc0d3f386f2c037ab062b9263ac9a773289f1bac)
* [ErrorDetails LocalDateTime 직렬화 문제 - cache 제거후 정상동작, objectMapper Java…](https://github.com/f-lab-edu/ward-study-reservation/pull/28/commits/bd63aeda0b844047a66b74c5092627ea60f9f059)