### PR TITLE
[#20] StudyGroup findAll() type, keyword 별로 검색 조건 추가

### DIFF
--- a/src/main/java/com/dsg/wardstudy/controller/reservation/ReservationController.java
+++ b/src/main/java/com/dsg/wardstudy/controller/reservation/ReservationController.java
@@ -87,7 +87,7 @@ public class ReservationController {
     public ResponseEntity<String> deleteById(
             @PathVariable("userId") Long userId,
             @PathVariable("reservationId") String reservationId) {
-        log.info("reservation deleteById, reservationId: {}", reservationId);
+        log.info("reservation deleteById, userId: {}, reservationId: {}" ,userId, reservationId);
         reservationService.deleteById(userId, reservationId);
         return new ResponseEntity<>("a reservation successfully deleted!", HttpStatus.OK);
     }

--- a/src/main/java/com/dsg/wardstudy/controller/studyGroup/StudyGroupController.java
+++ b/src/main/java/com/dsg/wardstudy/controller/studyGroup/StudyGroupController.java
@@ -41,10 +41,12 @@ public class StudyGroupController {
     // 스터디그룹 전체조회
     @GetMapping("/study-group")
     public ResponseEntity<PageResponse.StudyGroup> getAllPage(
-            @PageableDefault(page = 0, size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
+            @PageableDefault(page = 0, size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
+            @RequestParam(value = "type", required = false) String type,
+            @RequestParam(value = "keyword", required = false) String keyword
             ) {
-        log.info("studyGroup getAll");
-        return ResponseEntity.ok(studyGroupService.getAll(pageable));
+        log.info("studyGroup getAll type: {}, keyword: {}", type, keyword);
+        return ResponseEntity.ok(studyGroupService.getAll(pageable, type, keyword));
     }
 
     // 사용자가 참여한 스터디그룹 조회

--- a/src/main/java/com/dsg/wardstudy/repository/studyGroup/StudyGroupRepository.java
+++ b/src/main/java/com/dsg/wardstudy/repository/studyGroup/StudyGroupRepository.java
@@ -2,10 +2,11 @@ package com.dsg.wardstudy.repository.studyGroup;
 
 import com.dsg.wardstudy.domain.studyGroup.StudyGroup;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 
 import java.util.List;
 
-public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long> {
+public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long>, QuerydslPredicateExecutor<StudyGroup> {
 
     // in 절안에 컬렉션 findByIdIn
     List<StudyGroup> findByIdIn(List<Long> ids);

--- a/src/main/java/com/dsg/wardstudy/service/studyGroup/StudyGroupService.java
+++ b/src/main/java/com/dsg/wardstudy/service/studyGroup/StudyGroupService.java
@@ -13,7 +13,7 @@ public interface StudyGroupService {
 
     StudyGroupResponse getById(Long studyGroupId);
 
-    PageResponse.StudyGroup getAll(Pageable pageable);
+    PageResponse.StudyGroup getAll(Pageable pageable, String type, String keyword);
 
     Long updateById(Long userId, Long studyGroupId, StudyGroupRequest studyGroupRequest);
 

--- a/src/main/java/com/dsg/wardstudy/service/studyGroup/StudyGroupServiceImpl.java
+++ b/src/main/java/com/dsg/wardstudy/service/studyGroup/StudyGroupServiceImpl.java
@@ -25,6 +25,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 import java.util.Optional;
@@ -136,7 +137,7 @@ public class StudyGroupServiceImpl implements StudyGroupService {
         booleanBuilder.and(booleanExpression);
 
         // 검색 조건이 없는 경우
-        if (type == null || type.trim().length() == 0) {
+        if (!StringUtils.hasText(type)) {
             return booleanBuilder;
         }
 

--- a/src/test/java/com/dsg/wardstudy/controller/studyGroup/StudyGroupControllerTest.java
+++ b/src/test/java/com/dsg/wardstudy/controller/studyGroup/StudyGroupControllerTest.java
@@ -1,5 +1,6 @@
 package com.dsg.wardstudy.controller.studyGroup;
 
+import com.dsg.wardstudy.domain.studyGroup.QStudyGroup;
 import com.dsg.wardstudy.domain.studyGroup.StudyGroup;
 import com.dsg.wardstudy.domain.user.User;
 import com.dsg.wardstudy.domain.user.UserGroup;
@@ -11,6 +12,7 @@ import com.dsg.wardstudy.exception.WSApiException;
 import com.dsg.wardstudy.service.studyGroup.StudyGroupService;
 import com.dsg.wardstudy.type.UserType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.querydsl.core.BooleanBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -119,7 +121,22 @@ class StudyGroupControllerTest {
         }
         Pageable pageable = PageRequest.of(0, 10, Sort.by("id").descending());
 
-        given(studyGroupService.getAll(pageable))
+        QStudyGroup qStudyGroup = QStudyGroup.studyGroup;
+
+        String type = "t";
+        String keyword = "test";
+
+        // 검색조건 추가
+        BooleanBuilder conditionBuilder = new BooleanBuilder();
+
+        if(type.contains("t")) {
+            conditionBuilder.or(qStudyGroup.title.contains(keyword));
+        }
+        if(type.contains("c")) {
+            conditionBuilder.or(qStudyGroup.content.contains(keyword));
+        }
+
+        given(studyGroupService.getAll(pageable, type, keyword))
                 .willReturn(PageResponse.StudyGroup.builder()
                         .content(studyGroupResponses)
                         .pageNo(pageable.getPageNumber())
@@ -133,11 +150,13 @@ class StudyGroupControllerTest {
                         .param("page", "0")
                         .param("size", "10")
                         .param("sort", "id,desc")
+                        .param("type", "t")
+                        .param("keyword", "test")
                 )
                 .andDo(print())
                 .andExpect(status().isOk());
 
-        verify(studyGroupService).getAll(pageable);
+        verify(studyGroupService).getAll(pageable, type, keyword);
     }
 
     @Test

--- a/src/test/java/com/dsg/wardstudy/service/studyGroup/StudyGroupServiceTest.java
+++ b/src/test/java/com/dsg/wardstudy/service/studyGroup/StudyGroupServiceTest.java
@@ -1,6 +1,7 @@
 package com.dsg.wardstudy.service.studyGroup;
 
 import com.dsg.wardstudy.domain.reservation.Reservation;
+import com.dsg.wardstudy.domain.studyGroup.QStudyGroup;
 import com.dsg.wardstudy.domain.studyGroup.StudyGroup;
 import com.dsg.wardstudy.domain.user.User;
 import com.dsg.wardstudy.domain.user.UserGroup;
@@ -14,6 +15,7 @@ import com.dsg.wardstudy.repository.studyGroup.StudyGroupRepository;
 import com.dsg.wardstudy.repository.user.UserGroupRepository;
 import com.dsg.wardstudy.repository.user.UserRepository;
 import com.dsg.wardstudy.type.UserType;
+import com.querydsl.core.BooleanBuilder;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -148,7 +150,7 @@ class StudyGroupServiceTest {
 
     @Test
     public void givenStudyGroupList_whenGetAll_thenReturnStudyGroupResponseList() {
-        // TODO : paging NPE 발생 issue#23
+        // TODO : paging NPE 발생 issue#23 findAll(pageable)부터 안됐음.
         // given - precondition or setup
         StudyGroup studyGroup1 = StudyGroup.builder()
                 .id(100L)
@@ -156,14 +158,29 @@ class StudyGroupServiceTest {
                 .content("인원 6명의 스터디그룹을 모집합니다.")
                 .build();
 
-        Pageable pageable = PageRequest.of(0, 2, Sort.by("id").descending());
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("id").descending());
 
-        given(studyGroupRepository.findAll(pageable).getContent())
+        QStudyGroup qStudyGroup = QStudyGroup.studyGroup;
+
+        String type = "t";
+        String keyword = "test";
+
+        // 검색조건 추가
+        BooleanBuilder conditionBuilder = new BooleanBuilder();
+
+        if(type.contains("t")) {
+            conditionBuilder.or(qStudyGroup.title.contains(keyword));
+        }
+        if(type.contains("c")) {
+            conditionBuilder.or(qStudyGroup.content.contains(keyword));
+        }
+
+        given(studyGroupRepository.findAll(conditionBuilder, pageable).getContent())
                 .willReturn(List.of(studyGroup, studyGroup1));
         // when - action or the behaviour that we are going test
 
 
-        PageResponse.StudyGroup studyGroupPageResponses = studyGroupService.getAll(pageable);
+        PageResponse.StudyGroup studyGroupPageResponses = studyGroupService.getAll(pageable, type, keyword);
         log.info("studyGroupPageResponses: {}", studyGroupPageResponses);
         // then - verify the output
         assertThat(studyGroupPageResponses).isNotNull();
@@ -173,6 +190,7 @@ class StudyGroupServiceTest {
 
     @Test
     public void givenStudyGroupList_whenGetAll_Negative_thenReturnStudyGroupResponseList() {
+        // TODO : paging NPE 발생 issue#23
         // given - precondition or setup
         StudyGroup studyGroup1 = StudyGroup.builder()
                 .id(2L)
@@ -182,10 +200,25 @@ class StudyGroupServiceTest {
 
         Pageable pageable = PageRequest.of(0, 10, Sort.by("id").descending());
 
-        given(studyGroupRepository.findAll(pageable).getContent())
+        QStudyGroup qStudyGroup = QStudyGroup.studyGroup;
+
+        String type = "t";
+        String keyword = "test";
+
+        // 검색조건 추가
+        BooleanBuilder conditionBuilder = new BooleanBuilder();
+
+        if(type.contains("t")) {
+            conditionBuilder.or(qStudyGroup.title.contains(keyword));
+        }
+        if(type.contains("c")) {
+            conditionBuilder.or(qStudyGroup.content.contains(keyword));
+        }
+
+        given(studyGroupRepository.findAll(conditionBuilder, pageable).getContent())
                 .willReturn(Collections.emptyList());
         // when - action or the behaviour that we are going test
-        PageResponse.StudyGroup studyGroupPageResponses = studyGroupService.getAll(pageable);
+        PageResponse.StudyGroup studyGroupPageResponses = studyGroupService.getAll(pageable, type, keyword);
         log.info("studyGroupPageResponses: {}", studyGroupPageResponses);
         // then - verify the output
         assertThat(studyGroupPageResponses).isNull();


### PR DESCRIPTION
### Description
* querydsl booleanBuilder 사용, type, keyword 별로 검색 조건 추가
* (https://github.com/f-lab-edu/ward-study-reservation/issues/23#issue-1256476618) 문제는 남아있음.

### 중요 Commit 정리
* [querydsl booleanBuilder 이용 - title, content 검색조건 로직 추가](https://github.com/f-lab-edu/ward-study-reservation/commit/b9aaed6156a484ee3ee9bd6bc595b5aef665497a)